### PR TITLE
first attempt on a yyy debugging

### DIFF
--- a/weird.yscript
+++ b/weird.yscript
@@ -1,0 +1,74 @@
+!yamlscript/v0
+
+defn divisors(n):
+  loop [divs [1], divs2 [], i 2]:
+    if ((i ** 2) <= n):
+      do:
+        .[divs divs2] =:
+          if ((n % i) == 0):
+            do:
+              divs =: divs.conj(i)
+              j =: n / i
+              divs2 =:
+                if not(i = j):
+                  divs2.conj(j)
+                  divs2
+              =>: .[divs divs2]
+            =>: .[divs divs2]
+        recur: divs divs2 i.inc()
+      =>: divs2 + divs.reverse()
+
+defn abundant(n, divs):
+  (+ divs*) > n
+
+defn semiperfect(n, divs):
+  if (divs.count() > 0):
+    do:
+      h =: divs.first()
+      t =: divs.rest()
+      if (n < h):
+        semiperfect: n t
+        =>:
+          (n = h) ||
+          semiperfect((n - h) t) ||
+          semiperfect(n t)
+    =>: false
+
+defn sieve(limit):
+  loop [i 2, w1 vec([false] * limit)]:
+    if (i < limit):
+      recur (i + 2):
+        if not(w1.nth(i)):
+          do:
+            divs =: divisors(i)
+            if not(abundant(i divs)):
+              assoc w1: i true
+              if semiperfect(i divs):
+                loop [j i, w3 w1]:
+                  if (j < limit):
+                    recur: (j + i) assoc(w3 j true)
+                    =>: w3
+                =>: w1
+          =>: w1
+      =>: w1
+
+result =: atom([])
+
+defn calc(max):
+  w =: sieve(48000)
+  say: "The first $max weird numbers:"
+  loop [n 2, count 0]:
+    when (count < max):
+      recur (n + 2):
+        if not(w.nth(n)):
+          do:
+            swap!: result conj n
+            print: "$n "
+            inc: count
+          =>: count
+  say:
+
+defonce: dummy calc(100)
+
+defn main(max=25):
+     say: result

--- a/weird.yscript
+++ b/weird.yscript
@@ -52,7 +52,7 @@ defn sieve(limit):
           =>: w1
       =>: w1
 
-result =: atom([])
+defonce: result atom([])
 
 defn calc(max):
   w =: sieve(48000)
@@ -71,4 +71,4 @@ defn calc(max):
 defonce: dummy calc(100)
 
 defn main(max=25):
-     say: result
+     say: deref(result)

--- a/weirdloader.yscript
+++ b/weirdloader.yscript
@@ -1,0 +1,5 @@
+!yamlscript/v0
+say: "at first takes a while"
+load: "weird.yscript"
+say: "then goes fast"
+load: "weird.yscript"


### PR DESCRIPTION
The command
```
$ ys -d -e '+: 1 2'
```
does not print the result `3` on screen. With this hack, adding a blank before the colon, i.e.
```
ys -d -e '+ : 1 2'
```
prints the result `3`