### PR TITLE
add a core function comile: next to load:

### DIFF
--- a/core/src/yamlscript/runtime.clj
+++ b/core/src/yamlscript/runtime.clj
@@ -54,6 +54,7 @@
 
               ;; clojure.core functions overridden by YS
               'load (sci/copy-var ys.ys/load-file nil)
+              'compile (sci/copy-var ys.ys/compile-file nil)
               'use (sci/copy-var ys.ys/use nil)
 
               ;; clojure.core functions not added by SCI

--- a/core/src/ys/ys.clj
+++ b/core/src/ys/ys.clj
@@ -74,6 +74,14 @@
 (defn if [cond then else]
   (if cond then else))
 
+(defn compile-file [ys-file]
+  (let [ys-file (abspath ys-file (dirname @sci/file))
+        clj-code (->
+                   ys-file
+                   slurp
+                   yamlscript.compiler/compile)]
+    clj-code))
+
 (defn load-file [ys-file]
   (let [ys-file (abspath ys-file (dirname @sci/file))
         clj-code (->


### PR DESCRIPTION
currently `result =: load("file.ys")` executes the program, and returns its result

this patch newly adds `compile` next to already existing `load`, where `cli-code =: compile("file.ys")` returns the Clojure code of the program as a string.

This `compile` becomes useful as soon as it lands in the Python Loader Library, because then Python users can generate C++ code (using Ferret). This is then a way to speed up heavy Python calculations.